### PR TITLE
ヘッダーのテンプレート化

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,7 +1,7 @@
 @import "font-awesome";
 @import "reset";
-@import "footer";
-@import "header";
-@import "items/buycheck";
-@import "mypage";
-@import "details";
+@import "module/footer";
+@import "module/header";
+// @import "items/buycheck";
+// @import "mypage";
+// @import "details";

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,35 +7,8 @@
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    %link{:href => "https://use.fontawesome.com/releases/v5.6.3/css/all.css", :rel => "stylesheet"}/
+
     %script{:src => "https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"}
   %body
-    .header
-      .header__container
-        .container__top
-          %a{href:"/"}
-            = image_tag "logo.svg", size: "134x36", alt: "mercari",class: "logo"
-          %form.header__form{:action => "https://www.mercari.com/jp/search/"}
-            %input.input-default{:name => "keyword", :placeholder => "何かお探しですか？", :type => "search", :value => ""}/
-            %i.fa.fa-search.icon-search
-
-        .container__bottom
-          .container__bottom-left
-            %ul
-              %li.fa.fa-list-ul.icon
-                カテゴリーから探す
-              %li.fa.fa-tag.icon
-                ブランドから探す
-          .container__bottom-right.icon
-            %ul
-              %li.fa.fa-heart.icon
-                いいね！一覧
-              %li.fa.fa-bell.icon
-                お知らせ
-              %li.fa.fa-check.icon
-                やることリスト
-              %li.fa.fa-user-circle.icon
-                %a{href:"items/show"}
-                  マイページ
-      .header__bred-crumbs
-        %p メルカリ > カテゴリー一覧
     = yield

--- a/app/views/module/_header.html.haml
+++ b/app/views/module/_header.html.haml
@@ -1,0 +1,31 @@
+.header
+  .header__container
+    .container__top
+      %a{href:"/"}
+        = image_tag "logo.svg", size: "134x36", alt: "mercari",class: "logo"
+      %form.header__form{:action => "https://www.mercari.com/jp/search/"}
+        %input.input-default{:name => "keyword", :placeholder => "何かお探しですか？", :type => "search", :value => ""}/
+        %i.fa.fa-search.icon-search
+
+    .container__bottom
+      .container__bottom-left
+        %ul
+          %li.fa.fa-list-ul.icon
+            カテゴリーから探す
+          %li.far.fa-tag.icon
+            ブランドから探す
+      .container__bottom-right.icon
+        %ul
+          %li.far.fa-heart.icon
+            いいね！一覧
+          -# %li.far.fa-bell.icon
+          %li
+            %i.far.fa-bell
+              お知らせ
+          %li.fa.fa-check.icon
+            やることリスト
+          %li.far.fa-user-circle.icon
+            %a{href:"items/show"}
+              マイページ
+  .header__bred-crumbs
+    %p メルカリ > カテゴリー一覧


### PR DESCRIPTION
# What
・application.html.haml→部分テンプレートに変更
・application.scssのルート変更

・font-awsomeの適用をCDNでも行えるようにした



# Why
商品購入ページなど、ヘッダーを表示しないページがあるため。
