### PR TITLE
ユーザーログアウトページ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,3 +9,4 @@
 @import "mypage-sidebar";
 @import "shipping";
 @import "details";
+@import "items/logout";

--- a/app/assets/stylesheets/items/logout.scss
+++ b/app/assets/stylesheets/items/logout.scss
@@ -1,0 +1,25 @@
+.mypage-content {
+  width: 700px;
+  float: right;
+  border-top: 1px solid #f5f5f5;
+  padding: 64px;
+  box-sizing: border-box;
+  background: #fff;
+  &__logoutbox {
+    max-width: 320px;
+    margin: 0 auto;
+    height: 50px;
+    .logoutbutton {
+      background: #ea352d;
+      border: 1px solid #ea352d;
+      color: #fff;
+      display: block;
+      width: 100%;
+      line-height: 48px;
+      font-size: 14px;
+      border: 1px solid transparent;
+      cursor: pointer;
+      text-align: center;
+    }
+  }
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,6 +5,9 @@ class ItemsController < ApplicationController
   def mypage
   end
 
+  def logout
+  end
+
   def buy
   end
 

--- a/app/views/items/logout.html.haml
+++ b/app/views/items/logout.html.haml
@@ -1,0 +1,11 @@
+%header
+  = render 'module/header.html.haml'
+.mypage
+  %main.mypage__box
+    .maypage-sidebar
+      = render 'module/mypage-sidebar'
+    .mypage-content
+      .mypage-content__logoutbox
+        .mypage-content__logoutbox__logout
+          = button_to "ログアウト",{controller: 'items', action: 'mypage'}, {method: :get, class: "logoutbutton"}
+              

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       get 'buycheck'
       get 'shipping'
       get 'mypage'
+      get 'logout'
     end
   end
 end


### PR DESCRIPTION
# What
ユーザーログアウトページを追加した。
ヘッダー・フッダー部分はトップページで実装するため、それ以外の部分を作成した。
ユーザーコントローラーがまだ実装されていないため、ルーティングやログアウトボタンを押した場合に送られるコントローラー、アクション、メソッドは仮置きにしている。

# Why
ユーザーがログアウトする場合に必須のViewであるため。

## スクリーンショット
![スクリーンショット 2019-09-10 18 35 52](https://user-images.githubusercontent.com/53936988/64607087-bc8ea980-d402-11e9-82c9-aef14770031a.png)
