### PR TITLE
ユーザープロフィール編集ページ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,3 +10,4 @@
 @import "shipping";
 @import "details";
 @import "items/logout";
+@import "items/user_edit";

--- a/app/assets/stylesheets/items/user_edit.scss
+++ b/app/assets/stylesheets/items/user_edit.scss
@@ -1,0 +1,72 @@
+.mypage__box__editbox {
+  background: #fff;
+  width: 700px;
+  float: right;
+  &__head {
+    font-size: 24px;
+    padding: 8px 24px;
+    border-bottom: 1px solid #f5f5f5;
+    text-align: center;
+    line-height: 1.4;
+    font-weight:bold;
+  }
+  &__form__edit-icon {
+    padding: 72px 16px 24px;
+    background-image: url(user-bg.jpg);
+    background-repeat: no-repeat;
+    background-size: cover;
+    text-align: center;
+    font-size: 0;
+    & img {
+      display: inline-block;
+      overflow: hidden;
+      width: 60px;
+      height: 60px;
+      border-radius: 50%;
+      vertical-align: middle;  
+    }
+    .input-user-edit-nickname {
+      width: 220px;
+      margin: 0 0 0 8px;
+      vertical-align: middle;
+      height: 48px;
+      padding: 10px 16px 8px;
+      border-radius: 4px;
+      border: 1px solid #ccc;
+      background: #fff;
+      line-height: 1.5;
+      font-size: 16px;
+      box-sizing: border-box;
+    }
+  }
+  &__form__edit-profilebox {
+    padding: 40px 16px;
+    .input-user-edit-profile {
+      display: block;
+      min-height: 216px;
+      width: 100%;
+      max-width: 100%;
+      padding: 10px;
+      border: 1px solid #ccc;
+      background: #fff;
+      font-size: 16px;
+      line-height: 1.5;
+      box-sizing: border-box;
+    }
+    .mypage__box__editbox__form__btn {
+      margin: 16px 0 0;
+      background: #ea352d;
+      border: 1px solid #ea352d;
+      color: #fff;
+      display: block;
+      width: 100%;
+      line-height: 48px;
+      font-size: 14px;
+      border: 1px solid transparent;
+      -webkit-transition: all ease-out .3s;
+      transition: all ease-out .3s;
+      cursor: pointer;
+      text-align: center;
+    }
+  }
+}

--- a/app/assets/stylesheets/items/user_edit.scss
+++ b/app/assets/stylesheets/items/user_edit.scss
@@ -53,7 +53,7 @@
       line-height: 1.5;
       box-sizing: border-box;
     }
-    .mypage__box__editbox__form__btn {
+    &__form__btn {
       margin: 16px 0 0;
       background: #ea352d;
       border: 1px solid #ea352d;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,6 +8,9 @@ class ItemsController < ApplicationController
   def logout
   end
 
+  def user_edit
+  end
+
   def buy
   end
 

--- a/app/views/items/user_edit.html.haml
+++ b/app/views/items/user_edit.html.haml
@@ -1,0 +1,18 @@
+%header
+  = render 'module/header.html.haml'
+.mypage
+  %main.mypage__box
+    .maypage-sidebar
+      = render 'module/mypage-sidebar'
+    .mypage__box__editbox
+      .mypage__box__editbox__head
+        プロフィール
+      %form.mypage__box__editbox__form
+        .mypage__box__editbox__form__edit-icon
+          .mypage__box__editbox__form__edit-icon__figure
+            = image_tag 'member_photo.png'
+            %input.input-user-edit-nickname{name: "nickname", placeholder: "例)AYA☆セール中", type: "text", value: "ユーザー"}
+        .mypage__box__editbox__form__edit-profilebox
+          %textarea.input-user-edit-profile{name: "nickname", placeholder: "例）こんにちは☆ ご覧いただきありがとうございます！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取引できるよう心がけていますので、商品や発送方法などご質問がありましたらお気軽にどうぞ♪"}
+          = button_to "変更する",{controller: 'items', action: 'mypage'}, {method: :get, class: "mypage__box__editbox__form__btn"}
+= render 'module/footer'

--- a/app/views/module/_mypage-sidebar.html.haml
+++ b/app/views/module/_mypage-sidebar.html.haml
@@ -72,7 +72,7 @@
       設定
     %ul.maypage__box__side__sidebar__list
       %li
-        = link_to("#", class: 'maypage__box__side__sidebar__list__item') do
+        = link_to("user_edit", class: 'maypage__box__side__sidebar__list__item') do
           プロフィール
           %i.fa.fa-chevron-right
       %li

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       get 'shipping'
       get 'mypage'
       get 'logout'
+      get 'user_edit'
     end
   end
 end


### PR DESCRIPTION
# What
ユーザープロフィール編集画面を追加した。
ヘッダーとフッダーはトップページで作成するため、それ以外の部分を作成した。
ユーザーコントローラーがまだ実装されていないため、ルーティング、サイドバーのリンク、変更ボタンから送られるコントローラー、アクション、メソッドなどは仮置きにしている。

# Why
ユーザー編集機能実装のために必要であるため。

## スクリーンショット
![スクリーンショット 2019-09-11 2 28 13](https://user-images.githubusercontent.com/53936988/64636174-1eb7d080-d43c-11e9-8ab3-58a0acae3c09.png)
