### PR TITLE
自分の出品した商品に編集ボタンを追加

### DIFF
--- a/app/assets/javascripts/item/edit.js
+++ b/app/assets/javascripts/item/edit.js
@@ -1,6 +1,6 @@
 $(function() {
   $('.delete').on('click', function() {
     $('.check_box').val()
-    $(this).parent().parent().remove();
+    $(this).parent().parent().hide();
   });
 });

--- a/app/assets/stylesheets/items/edit.scss
+++ b/app/assets/stylesheets/items/edit.scss
@@ -5,6 +5,14 @@
   color: #333;
   height: 100%;
   width: 100%;
+  input[type=checkbox] {
+    display:none;
+  }
+  label:hover {
+    cursor: pointer;
+    color:#0099e8;
+    
+  }
 }
 
 .item-edit-container {

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -31,8 +31,8 @@
                     .image-box
                       = image_tag image, size: "120x120", class: 'edit-image'
                       .button
-                        = f.label "削除", {for: "image_ids"}
                         = f.check_box :image_ids, {multiple: true}, image.id, false
+                        = f.label "削除", {for: "item_image_ids_#{image.id}", class: 'delete'}
               .sell-dropbox-container.clearfix
                 .sell-upload-items-container
                   .sell-upload-items

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -83,6 +83,15 @@
             残高 ¥3,250 をお持ちです
           %a.item-buy-btn{href: "/items/buycheck/#{@item.id}"}
             購入画面に進む
+        - if @item.user_id == current_user.id
+          .listing-item-change-box
+            = link_to '商品の編集', edit_item_path, class: "btn-default btn-red"
+            %p.text-center or
+            %form{action: "/jp/items/deactivate/m49348093442/", method: "POST", novalidate: "novalidate"}
+              %input{name: "__csrf_value", type: "hidden", value: "f834660aefe34bf4fffc3bf2df7b816c84b48f9660456f36524b1858cd574d6f557b238c71986388d369e47bdc5e03e5eaf4182769b02e26fd704172914a87c90"}/
+              %button.btn-default.btn-gray_sub{type: "submit"} 出品を一旦停止する
+              = link_to 'この商品を削除する', item_path, method: :delete, class:"btn-default btn-gray_sub"
+
       %p.item-description-inner
         = @item.description
       .item-button-container

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -135,6 +135,7 @@
     = render 'module/buy_image_box'
     = render 'module/buy_image_box'
     = render 'module/buy_image_box'
+- breadcrumb :items_show
 = render 'module/footer'
 
 

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -44,6 +44,17 @@ crumb :sold do
   parent :mypage
 end
 
+crumb :items_show do
+  @item = Item.find_by(id:params[:id])
+  link "#{@item.name}"
+  parent :root
+end
+
+# crumb :show_title do |show_title|
+#   show_title = Post.find_by(id: params[:id])
+#   link show_title.title
+#   parent :tag
+# end
 
 
 # マイページ-クレジットカード情報入力


### PR DESCRIPTION
# what
自分の出品した商品に編集ボタンを追加
編集画面の丈夫にぱんくずを追加
編集画面で削除したい画像を選ぶとviewから一時的に消え、編集完了ボタンを押すとDBからも削除される仕様に変更

# why
ユーザビリティ向上のため